### PR TITLE
Fix MIDI output settings crash when device name is None

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,17 @@ on:
   repository_dispatch:
 
 jobs:
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest
+      - run: pytest
+
   # Build job. Builds app for Android with Buildozer
   build-android:
     name: Build for Android

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "midistrum"
+description = "Omnichord-style MIDI strumming app for Android"
+requires-python = ">=3.11"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/android_midi.py
+++ b/src/android_midi.py
@@ -10,16 +10,30 @@ MidiInputPort = autoclass('android.media.midi.MidiInputPort')
 Context = autoclass('android.content.Context')
 
 
+def get_midi_device_display_name(dev_info_casted, index):
+    """Return a human-readable name for a MIDI device, with fallbacks."""
+    props = dev_info_casted.getProperties()
+    name = props.getString(MidiDeviceInfo.PROPERTY_NAME)
+    if name:
+        return name
+    product = props.getString(MidiDeviceInfo.PROPERTY_PRODUCT)
+    if product:
+        return product
+    manufacturer = props.getString(MidiDeviceInfo.PROPERTY_MANUFACTURER)
+    if manufacturer:
+        return manufacturer
+    return f"MIDI Device {index + 1}"
+
+
 def get_midi_ports_list():
     return_value = []
     service = activity.getSystemService(Context.MIDI_SERVICE)
     m = cast('android.media.midi.MidiManager', service)
     device_list = m.getDevices()
     
-    for dev_info in device_list:
+    for index, dev_info in enumerate(device_list):
         dev_info_casted = cast('android.media.midi.MidiDeviceInfo', dev_info)
-        # Java: deviceName = devInfo.getProperties().getString(MidiDeviceInfo.PROPERTY_NAME);
-        device_name = dev_info_casted.getProperties().getString(MidiDeviceInfo.PROPERTY_NAME);
+        device_name = get_midi_device_display_name(dev_info_casted, index)
         return_value.append((device_name, dev_info_casted))
     return return_value
 

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ from kivy.app import App
 from kivy.properties import NumericProperty, StringProperty, ObjectProperty, ListProperty, NumericProperty
 # from kivy.lang import Builder
 from kivy.factory import Factory
+from kivy.uix.label import Label
 from kivy.uix.settings import SettingItem
 from kivy.uix.widget import Widget
 from kivy.graphics import Rectangle, Color
@@ -169,6 +170,20 @@ class SettingMIDI(SettingItem):
         self.popup.dismiss()
 
     def _create_popup(self, instance):
+        try:
+            self._build_midi_popup()
+        except Exception as e:
+            print(f"Error creating MIDI popup: {e}")
+            error_content = BoxLayout(orientation='vertical', padding=10, spacing=10)
+            error_content.add_widget(Label(text=f"Could not list MIDI devices:\n{e}"))
+            dismiss_btn = Button(text='OK', size_hint_y=None, height=50)
+            error_content.add_widget(dismiss_btn)
+            self.popup = Popup(title='MIDI Error', content=error_content,
+                               size_hint=(0.8, 0.4))
+            dismiss_btn.bind(on_release=self.popup.dismiss)
+            self.popup.open()
+
+    def _build_midi_popup(self):
         global midi
         root = ScrollView(size_hint=(1, None), size=(1, 200))
 
@@ -188,22 +203,15 @@ class SettingMIDI(SettingItem):
         print(height)
         popup.height = 150
 
-        # content.add_widget(Widget(size_hint_y=None, height=200))
         uid = str(self.uid)
 
         if platform == 'android':
             for device_name, device in devices:
+                display_name = device_name if device_name else "Unknown MIDI Device"
                 state = 'down' if device_name == self.value else 'normal'
-                btn = ToggleButton(text=device_name, state="normal", group=uid)
+                btn = ToggleButton(text=display_name, state="normal", group=uid)
                 btn.bind(on_release=self._set_option)
                 content.add_widget(btn)
-
-            # for i in range(device_count):
-            #     for port in devices[i].getPorts():
-            #         if midi.getName(devices[i]) != 'MasterGrid' and (
-            #                 port.getType() == 2 or midi.getName(devices[i]) == self.value):
-            #             state = 'down' if midi.getName(devices[i]) == self.value else 'normal'
-                        
         else:
             for i in range(device_count):
                 if pygame.midi.get_device_info(i)[3] == 1 and (
@@ -351,15 +359,17 @@ class Midistrum(App):
 
     def on_config_change(self, config, section, key, value):
         if key == 'midi_device':
-            # TODO CLOSE OLD
             print("Set_Foncig")
             try:
                 if get_main_app().midi_listner is not None:
                     get_main_app().midi_listner.close()
-            except:
-                pass
-            midi_device = App.get_running_app().config.get("Midistrum", "midi_device")
-            get_main_app().set_midi_device(midi_device)
+            except Exception as e:
+                print(f"Error closing previous MIDI device: {e}")
+            try:
+                midi_device = App.get_running_app().config.get("Midistrum", "midi_device")
+                get_main_app().set_midi_device(midi_device)
+            except Exception as e:
+                print(f"Error opening MIDI device: {e}")
 
 
 if __name__ == '__main__':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Shared fixtures that mock Android-specific modules for desktop testing."""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _install_android_mocks():
+    """Insert mock modules so android_midi can be imported without jnius/Android."""
+    mock_jnius = MagicMock()
+    mock_jnius.autoclass = MagicMock(side_effect=lambda cls: MagicMock(name=cls))
+    mock_jnius.cast = MagicMock(side_effect=lambda cls, obj: obj)
+
+    mocks = {
+        "jnius": mock_jnius,
+        "plyer": MagicMock(),
+        "plyer.platforms": MagicMock(),
+        "plyer.platforms.android": MagicMock(),
+        "android": MagicMock(),
+        "android.media": MagicMock(),
+        "android.media.midi": MagicMock(),
+    }
+    for name, mock in mocks.items():
+        sys.modules.setdefault(name, mock)
+
+
+_install_android_mocks()

--- a/tests/test_midi_device_names.py
+++ b/tests/test_midi_device_names.py
@@ -1,0 +1,105 @@
+"""Tests for MIDI device name fallback logic (fixes crash with None device names)."""
+
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from android_midi import get_midi_device_display_name
+
+
+def _make_device_info(name=None, product=None, manufacturer=None):
+    """Create a mock MidiDeviceInfo with configurable property values."""
+    props = MagicMock()
+
+    def get_string(key):
+        prop_map = {
+            "PROPERTY_NAME": name,
+            "PROPERTY_PRODUCT": product,
+            "PROPERTY_MANUFACTURER": manufacturer,
+        }
+        for mock_attr, value in prop_map.items():
+            if key is getattr(dev_info, mock_attr, None):
+                return value
+            if hasattr(key, '_mock_name') and mock_attr in str(key._mock_name):
+                return value
+        return name
+
+    props.getString = MagicMock(side_effect=get_string)
+    dev_info = MagicMock()
+    dev_info.getProperties.return_value = props
+    return dev_info
+
+
+class TestGetMidiDeviceDisplayName:
+    """Tests for get_midi_device_display_name fallback chain."""
+
+    def test_valid_name_passes_through(self):
+        dev = _make_device_info(name="Roland MIDI Keyboard")
+        result = get_midi_device_display_name(dev, 0)
+        assert result == "Roland MIDI Keyboard"
+
+    def test_none_name_falls_back_to_generic(self):
+        dev = _make_device_info(name=None)
+        result = get_midi_device_display_name(dev, 0)
+        assert result is not None
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_none_name_generic_includes_index(self):
+        dev = _make_device_info(name=None)
+        result = get_midi_device_display_name(dev, 4)
+        assert "5" in result
+
+    def test_empty_string_name_falls_back(self):
+        dev = _make_device_info(name="")
+        result = get_midi_device_display_name(dev, 0)
+        assert result is not None
+        assert len(result) > 0
+
+
+class TestGetMidiDeviceDisplayNameFallbackChain:
+    """Test the PROPERTY_NAME -> PROPERTY_PRODUCT -> PROPERTY_MANUFACTURER chain."""
+
+    def test_fallback_to_product(self):
+        props = MagicMock()
+        values = [None, "USB MIDI Interface", None]
+        props.getString = MagicMock(side_effect=values)
+        dev = MagicMock()
+        dev.getProperties.return_value = props
+
+        result = get_midi_device_display_name(dev, 0)
+        assert result == "USB MIDI Interface"
+
+    def test_fallback_to_manufacturer(self):
+        props = MagicMock()
+        values = [None, None, "Yamaha"]
+        props.getString = MagicMock(side_effect=values)
+        dev = MagicMock()
+        dev.getProperties.return_value = props
+
+        result = get_midi_device_display_name(dev, 0)
+        assert result == "Yamaha"
+
+    def test_fallback_to_generic_when_all_none(self):
+        props = MagicMock()
+        values = [None, None, None]
+        props.getString = MagicMock(side_effect=values)
+        dev = MagicMock()
+        dev.getProperties.return_value = props
+
+        result = get_midi_device_display_name(dev, 2)
+        assert result == "MIDI Device 3"
+
+    def test_name_preferred_over_product(self):
+        props = MagicMock()
+        values = ["My Synth"]
+        props.getString = MagicMock(side_effect=values)
+        dev = MagicMock()
+        dev.getProperties.return_value = props
+
+        result = get_midi_device_display_name(dev, 0)
+        assert result == "My Synth"


### PR DESCRIPTION
Android's MidiDeviceInfo.PROPERTY_NAME can return null for some devices, which caused a ValueError crash when creating ToggleButtons in the MIDI settings popup.

- Add fallback chain in get_midi_device_display_name(): tries PROPERTY_NAME, then PROPERTY_PRODUCT, PROPERTY_MANUFACTURER, and finally a generic label
- Wrap _create_popup in try-except to show error popup instead of crashing
- Add belt-and-suspenders None check in _build_midi_popup
- Improve error handling in on_config_change (log errors instead of bare except)
- Add pytest infrastructure and unit tests for device name fallback logic
- Add unit test CI job to GitHub Actions workflow

Fixes #5